### PR TITLE
Fix: Enable DynamoDB point-in-time recovery

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -76,6 +76,10 @@ resource "aws_dynamodb_table" "known_ai_senders" {
     projection_type = "ALL"
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   tags = {
     Project     = var.PROJECT_NAME
     Environment = var.environment
@@ -108,6 +112,10 @@ resource "aws_dynamodb_table" "known_non_ai_senders" {
   ttl {
     attribute_name = "ttl"
     enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
   }
 
   tags = {


### PR DESCRIPTION
## Summary
Implements point-in-time recovery for both DynamoDB tables to protect against data loss.

## Changes Made
- ✅ Added point-in-time recovery to `known_ai_senders` table
- ✅ Added point-in-time recovery to `known_non_ai_senders` table

## Testing
- Configuration validates correctly in Terraform
- Will be applied on next deployment

## Benefits
- 🛡️ **35 days of automatic backups**
- 🔄 **Point-in-time restore capability**
- 💰 **Minimal cost**: ~/bin/zsh.20/GB/month
- ⚡ **No performance impact**
- 🚀 **Immediate protection upon deployment**

## Deployment
After merging, run:
```bash
cd terraform/aws
terraform apply
```

Closes #44